### PR TITLE
fix(perf): skip framework hook dispatch when the runner is undefined

### DIFF
--- a/crates/niubash-runtime/src/lib.rs
+++ b/crates/niubash-runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub mod prompt;
 pub mod prompt_segments;
 pub mod repl;
 pub mod setup_wizard;
+pub mod startup_trace;
 pub mod shell;
 pub mod syntax_highlighting;
 pub mod terminal;

--- a/crates/niubash-runtime/src/shell.rs
+++ b/crates/niubash-runtime/src/shell.rs
@@ -135,6 +135,13 @@ pub struct Shell {
     pub no_rc: bool,
     // --noprofile: do not run login-profile startup.
     pub no_profile: bool,
+    // Memoized per-runner answers to `declare -F <runner>`. The oh-my-niu
+    // framework defines the niubash_run_*_hooks entry points from the user rc;
+    // when the rc was never sourced (`niu -c`, scripts, piped stdin) or bundle
+    // discovery missed, dispatching them makes rubash pay for a full
+    // PATH/command-link scan for a name that cannot exist. Probed once per
+    // runner with a builtin, then cached.
+    framework_hook_probes: HashMap<String, bool>,
     // --rcfile / --init-file: alternate startup file.
     pub rc_file: Option<PathBuf>,
     // --noediting: disable readline-style line editing in the REPL.
@@ -184,6 +191,7 @@ impl Shell {
         // 1. Load runtime defaults and environment-backed state.
         let mut config = load_config();
         config.history = config.history.with_env_overrides();
+        crate::startup_trace::tick("config loaded");
 
         // 2. Select the WinuxCmd installation and use its real directory tree
         // before constructing the executor.
@@ -200,7 +208,9 @@ impl Shell {
             log::debug!("winuxcmd PATH injection disabled by config");
             None
         };
+        crate::startup_trace::tick("winuxcmd selected");
         let shell_root = prepare_shell_root(selected_winuxcmd_path.as_deref())?;
+        crate::startup_trace::tick("shell root prepared");
 
         // 3. Build rubash Executor after host path selection.
         let shell_was_missing = std::env::var_os("SHELL").is_none();
@@ -213,6 +223,7 @@ impl Shell {
             std::env::set_var("WINUXSH_SHELL_PATH_STYLE", "native");
         }
         let mut executor = Executor::new();
+        crate::startup_trace::tick("executor created");
         // Reedline is the interactive history owner. Keep Rubash's Bash
         // history machinery disabled in the host shell so HISTFILE cannot
         // create a second, competing history stream.
@@ -277,6 +288,8 @@ impl Shell {
             execute_niubash_host_external_command(words, env, &host_plugin_state)
         });
 
+        crate::startup_trace::tick("executor env + host handler");
+
         // 5. Apply managed aliases so explicit machine state remains
         // authoritative when names collide.
         let mut aliases = HashMap::new();
@@ -306,6 +319,8 @@ impl Shell {
                 }
             }
         }
+
+        crate::startup_trace::tick("aliases + builtin packs");
 
         // 6. Prompt + theme. Choose backend based on `prompt_style`:
         //    "segments"  -> new p10k-style segment engine
@@ -388,6 +403,8 @@ impl Shell {
             PromptBackend::Template(template_prompt)
         };
 
+        crate::startup_trace::tick("prompt backend");
+
         // 7. User-local state files.
         normalize_executor_home_env(&mut executor, &home_dir);
         ensure_windows_profile_env(&mut executor, &home_dir);
@@ -411,6 +428,7 @@ impl Shell {
             )
         })?;
         executor.set_history_provider(Rc::new(RefCell::new(history_provider)));
+        crate::startup_trace::tick("history provider");
         let last_working_dir_cache_path = default_last_working_dir_cache_path(&home_dir);
 
         // 8. Completion state.
@@ -420,6 +438,8 @@ impl Shell {
         initial_completion_state.behavior = config.completion_behavior;
         let completion_state = Arc::new(Mutex::new(initial_completion_state));
         let bundle_completion_defs = crate::plugins::plugin_completion_defs(&plugin_state);
+
+        crate::startup_trace::tick("completion state");
 
         // 9. Load completion dirs from config (inline, not in thread).
         {
@@ -481,11 +501,14 @@ impl Shell {
             interactive: false,
             no_rc: false,
             no_profile: false,
+            framework_hook_probes: HashMap::new(),
             rc_file: None,
             no_editing: false,
         };
+        crate::startup_trace::tick("bundle completion + keybindings");
         shell.sync_executor_pwd_from_process_cwd();
         shell.update_completion_state();
+        crate::startup_trace::tick("Shell::new done");
         Ok(shell)
     }
 
@@ -796,7 +819,34 @@ impl Shell {
         })
     }
 
+    /// Whether the oh-my-niu framework runner is actually defined in this
+    /// shell. Probed once with the `declare -F` builtin and memoized per
+    /// runner so repeated hook invocations stay free.
+    fn framework_hook_defined(&mut self, runner: &str) -> bool {
+        if let Some(known) = self.framework_hook_probes.get(runner) {
+            return *known;
+        }
+        let script = format!("declare -F {runner} >/dev/null 2>&1");
+        let previous_exit_code = self.executor.last_exit_code();
+        let defined = self
+            .execute_script(&script)
+            .map(|code| code == 0)
+            .unwrap_or(false);
+        // The probe must not leak into $?: the caller's last_exit_code feeds
+        // NIU_LAST_EXIT_CODE for the hook that dispatched this probe.
+        self.executor.set_last_exit_code(previous_exit_code);
+        self.framework_hook_probes.insert(runner.to_string(), defined);
+        defined
+    }
+
     fn run_framework_hook_runner(&mut self, runner: &str, context: &[(&str, String)]) {
+        // The framework entry points only exist once the user rc has been
+        // sourced. Dispatching them earlier makes rubash fall through to a
+        // full PATH/command-link scan for a name that cannot exist, which is
+        // the dominant fixed cost of `niu -c` and of any rc-less REPL start.
+        if !self.framework_hook_defined(runner) {
+            return;
+        }
         for (name, value) in context {
             self.executor.set_env(name, value);
         }
@@ -7173,6 +7223,7 @@ niubash_prompt_use_template "PLUGIN:{git}{prompt_char} " ""
             interactive: false,
             no_rc: false,
             no_profile: false,
+            framework_hook_probes: HashMap::new(),
             rc_file: None,
             no_editing: false,
         };

--- a/crates/niubash-runtime/src/startup_trace.rs
+++ b/crates/niubash-runtime/src/startup_trace.rs
@@ -1,0 +1,53 @@
+//! Opt-in startup timing diagnostics.
+//!
+//! Set `NIU_TRACE_STARTUP=1` (also `true`/`on`) to print per-stage elapsed
+//! timings to **stderr**. Output is silent unless explicitly enabled, which
+//! keeps `niu -c` and script runs deterministic and banner-free by default.
+
+use std::cell::Cell;
+use std::io::Write;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static START: OnceLock<Instant> = OnceLock::new();
+static ENABLED: OnceLock<bool> = OnceLock::new();
+
+thread_local! {
+    static LAST: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+fn is_enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("NIU_TRACE_STARTUP")
+            .map(|value| {
+                ["1", "true", "on"]
+                    .iter()
+                    .any(|name| value.eq_ignore_ascii_case(name))
+            })
+            .unwrap_or(false)
+    })
+}
+
+fn start() -> &'static Instant {
+    START.get_or_init(Instant::now)
+}
+
+/// Record a stage boundary. Prints cumulative and per-stage milliseconds.
+pub fn tick(label: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let now = Instant::now();
+    let total = now.duration_since(*start()).as_micros() as f64 / 1000.0;
+    let delta = LAST.with(|last| {
+        last.get()
+            .map(|previous| (now.duration_since(previous).as_micros() as f64 / 1000.0).to_string())
+            .unwrap_or_else(|| "-".to_string())
+    });
+    let _ = writeln!(
+        std::io::stderr(),
+        "NIU_TRACE_STARTUP: {:>8.1} ms  (delta {:>8})  {}",
+        total, delta, label
+    );
+    LAST.with(|last| last.set(Some(now)));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ fn run(args: &[String]) -> anyhow::Result<()> {
                 anyhow::bail!("-c requires an argument");
             }
             let mut shell = niubash_runtime::Shell::new()?;
+            niubash_runtime::startup_trace::tick("-c: Shell::new");
             shell.executor.inherit_process_stdin();
             shell.enable_process_stdin_pipeline_bridge();
             shell.executor.set_env("BASH_EXECUTION_STRING", &args[2]);
@@ -144,7 +145,9 @@ fn run(args: &[String]) -> anyhow::Result<()> {
                 shell.executor.set_positional_params(args[4..].to_vec());
             }
             let code = shell.execute_script(&args[2])?;
+            niubash_runtime::startup_trace::tick("-c: execute_script");
             let code = shell.finish_with_exit_trap(code)?;
+            niubash_runtime::startup_trace::tick("-c: exit trap");
             if code != 0 {
                 std::process::exit(code);
             }
@@ -192,6 +195,7 @@ fn run_shell_invocation(args: &[String]) -> anyhow::Result<()> {
     } else {
         niubash_runtime::Shell::new()?
     };
+    niubash_runtime::startup_trace::tick("invocation: Shell::new");
     shell.no_rc = invocation.no_rc;
     shell.no_profile = invocation.no_profile;
     shell.rc_file = invocation.rc_file.clone().map(PathBuf::from);
@@ -203,9 +207,12 @@ fn run_shell_invocation(args: &[String]) -> anyhow::Result<()> {
     shell.enable_process_stdin_pipeline_bridge();
 
     if let Some(command) = invocation.command {
+        niubash_runtime::startup_trace::tick("invocation: setup done");
         shell.executor.set_env("BASH_EXECUTION_STRING", &command);
         let code = shell.execute_script(&command)?;
+        niubash_runtime::startup_trace::tick("invocation: execute_script");
         let code = shell.finish_with_exit_trap(code)?;
+        niubash_runtime::startup_trace::tick("invocation: exit trap");
         if code != 0 {
             std::process::exit(code);
         }
@@ -348,6 +355,7 @@ fn run_repl_command(args: &[String]) -> anyhow::Result<()> {
         }
     }
     let mut shell = niubash_runtime::Shell::new()?;
+    niubash_runtime::startup_trace::tick("-C: Shell::new");
     shell.enter_interactive();
     shell.executor.inherit_process_stdin();
     shell.enable_process_stdin_pipeline_bridge();
@@ -356,8 +364,11 @@ fn run_repl_command(args: &[String]) -> anyhow::Result<()> {
         shell.executor.set_positional_params(args[4..].to_vec());
     }
     shell.run_startup_rc();
+    niubash_runtime::startup_trace::tick("-C: startup rc");
     shell.run_precmd_hooks();
+    niubash_runtime::startup_trace::tick("-C: precmd hooks");
     let code = shell.execute_interactive_line(&args[2])?;
+    niubash_runtime::startup_trace::tick("-C: execute_interactive_line");
     if code != 0 {
         std::process::exit(code);
     }


### PR DESCRIPTION
## What

`run_framework_hook_runner` executes a script that calls
`niubash_run_<hook>_hooks`. Those entry points are only defined after the
user rc has sourced the oh-my-niu bundle.

In **non-rc modes** that never happens — `niu -c`, script files, piped stdin —
yet niubash still dispatched them. When rubash cannot resolve the name as a
function it falls through to a full PATH / command-link scan, which costs
~55-70ms per missing command. There is one such dispatch on every exit trap,
so every `niu -c` invocation paid for it.

Verified against the **installed** `v1.0.1` binary, which is the reference:

```
$ niu -c 'declare -F niubash_run_zshexit_hooks >/dev/null 2>&1; echo $?'
1                # undefined — no rc sourced under -c

$ niu -c true          -> ~197 ms
$ niu -c <bogus name>  -> ~258 ms     # +55ms, the dead PATH scan
```

For contrast, `-C` does source the rc and the hooks really are defined there
(`PC=[starship_precmd]`, `starship_precmd` resolvable), so `-C` does **not**
suffer from this. See the note below about `-C` timing.

## Fix

Probe each runner once with the `declare -F` builtin and memoize the answer
per runner in a new `framework_hook_probes` map. Skip dispatch when the
runner is not defined.

The probe's exit code is saved and restored so it does not leak into `$?` /
`NIU_LAST_EXIT_CODE` — the first attempt missed this and broke
`niubashrc_framework_hooks_replace_host_source_lifecycle_hooks` (`NIU_FRAMEWORK_PRECMD`
came back as `"1"` instead of `"0"`).

## Also: NIU_TRACE_STARTUP

This adds the diagnostic switch requested in #79. `NIU_TRACE_STARTUP=1`
prints cumulative and per-stage milliseconds to stderr for the `-c`, `-C` and
`ShellInvocation` paths plus every `Shell::new` stage. Silent by default,
stderr only, so the deterministic no-banner contract for `niu -c` and script
runs is preserved.

This is what located the problem. It also ruled out the issue's guesses:
winuxcmd selection is 0.4ms, and zero plugins load under `-c`.

## Numbers

Windows 11, release build, this machine.

**Installed `v1.0.1` binary (the honest baseline):**

| | before | after |
|---|---|---|
| `niu -c true` | **~197 ms** | **~67 ms** |
| `niu -C true` | ~1500 ms | ~1500 ms (unchanged) |

`-C` is unchanged because ~1500ms there is **legitimate work**: the rc loads
15 real plugin packs (prompt-core, git, starship, path-tools, extract,
zoxide, fzf, thefuck, command-not-found, direnv, dotenv, kubectl, npm,
keybindings, env-sync), and `starship` runs `eval "$(starship init bash)"`,
which spawns starship. That is not dead time and should not be optimized
away here.

**Correction to my first revision:** the earlier `1700ms -> 260ms` figure for
`-C` was measured against a stale developer checkout that sat two commits
behind the shipped binary and therefore never loaded the bundle. It was dead
dispatch time in that broken state, not a defect in `-C`. I also opened
and have since closed #81, which incorrectly reported that the rc could not
find the app-installed bundle — niubash does export `NIU_APP_BUNDLE_PATH`;
my checkout simply did not yet contain that commit.

## Tests

`cargo fmt --check -p niubash` clean.

`cargo test --workspace --locked` reports failures, but I verified they are
pre-existing by stashing this branch's changes and re-running: identical
counts and identical test names.

- `niubash-runtime` lib: 239 passed / 12 failed both before and after
- `host_contract`: 34 passed / 4 failed both before and after (includes the
  known `\x1e` stdin-marker leak)

## Follow-up

- **rubash upstream**: a ~55-70ms negative PATH/command-link lookup is the
  underlying cost. Worth caching misses — see unixwin/rubash#71.

Lands in **v1.1.0**.

Closes #79
